### PR TITLE
fix: Resolve Go build errors in system_info_view.go

### DIFF
--- a/src/infrastructure/context.go
+++ b/src/infrastructure/context.go
@@ -11,4 +11,6 @@ type Context interface {
 	Response(string, int, interface{}) error
 	GetFromToQuery() (config.From, config.To)
 	Request() context.Context
+	QueryParam(string) string
+	HTMLBlob(int, []byte) error
 }

--- a/src/infrastructure/system_info_view.go
+++ b/src/infrastructure/system_info_view.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/shun-shun123/bus-timer/src/config"
 	"github.com/shun-shun123/bus-timer/src/domain"
 	"github.com/shun-shun123/bus-timer/src/slack"
 )
@@ -42,8 +41,8 @@ func DebugSuccessSystemInfoRequest(c Context) error {
 
 func DebugNavitimeHTML(c Context) error {
 	// クエリパラメータからfrとtoを取得
-	fr := c.Context.QueryParam("fr")
-	to := c.Context.QueryParam("to")
+	fr := c.QueryParam("fr")
+	to := c.QueryParam("to")
 	log.Printf("Debug endpoint called with fr=%s, to=%s", fr, to)
 
 	approachInfoUrls := c.GetApproachInfoUrls()
@@ -99,5 +98,5 @@ func DebugNavitimeHTML(c Context) error {
 	log.Printf("Response body length: %d bytes", len(body))
 
 	// HTMLをそのまま返す（ステータスコードも一緒に返す）
-	return c.Context.HTMLBlob(resp.StatusCode, body)
+	return c.HTMLBlob(resp.StatusCode, body)
 }


### PR DESCRIPTION
- Add QueryParam and HTMLBlob methods to Context interface
- Fix Context field access by calling methods directly on interface
- Remove unused config import from system_info_view.go

This fixes the compilation errors:
- "c.Context undefined" errors
- "imported and not used" error for config package