### PR TITLE
Debug bus schedule API scraping issues

### DIFF
--- a/src/domain/approach.go
+++ b/src/domain/approach.go
@@ -57,17 +57,17 @@ func (infos ApproachInfos) GetFastThree() ApproachInfos {
 	hour := 99
 	min := 99
 	first := compareFastInfo{
-		index: 0,
+		index: -1,
 		hour: hour,
 		min: min,
 	}
 	second := compareFastInfo{
-		index: 1,
+		index: -1,
 		hour: hour,
 		min: min,
 	}
 	third := compareFastInfo{
-		index: 2,
+		index: -1,
 		hour: hour,
 		min: min,
 	}


### PR DESCRIPTION
Previously, first/second/third were initialized with index values of 0/1/2 but with invalid time values (hour: 99, min: 99). This caused inconsistent states where compareFastInfo had valid indices pointing to actual elements but invalid time values, leading to potential bugs.

Now initializing all indices to -1 to clearly mark them as uninitialized until they are properly set during the comparison loop.

## 目的

## 関連するIssue等
+ 

## レビューポイント
+ 

## 留意事項
+ 

## 残課題
+ 